### PR TITLE
Remove personal directory and change multiparameter_landscape_plotting.py plot setting

### DIFF
--- a/multiparameter_landscape_plotting.py
+++ b/multiparameter_landscape_plotting.py
@@ -80,7 +80,6 @@ def plot_a_two_parameter_landscape(multi_landscape: multiparameter_landscape, in
         title="Multiparameter Landscape k=" + str(index + 1),
         width=250,
         height=250,
-        sizing_mode='scale_both',
         match_aspect=True,
         toolbar_location=None
     )

--- a/rivet.py
+++ b/rivet.py
@@ -12,7 +12,7 @@ from typing import List, Tuple
 """An interface for rivet_console, using the command line
 and subprocesses."""
 
-rivet_executable = '/home/ollie/Documents/RIVET/MarchReinstall/rivet/rivet_console'
+rivet_executable = '<rivet_console location>'
 
 
 class PointCloud:


### PR DESCRIPTION
**Remove personal directory and change multiparameter_landscape_plotting.py plot setting**

- Remove personal directory in rivet.py and leave it for end-users to add path to `rivet_console` application
- remove a `scale_both` setting from multiparameter_landscape_plotting.py in order to print the family of multiparameter landscapes correctly